### PR TITLE
FIX: proper handling of objects without Object in prototype chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -610,15 +610,15 @@ module.exports = function(awsconfig, dynamodboptions) {
 
 			// Look for somthing like this: [!some_value]
 			// This will make sure the value is not update if already set
-			var conditional = /\[\!(.*)\]/g.exec(document[key]);
+			var conditional = typeof document[key] === 'string' && /\[\!(.*)\]/g.exec(document[key]);
 
 			// Look for somthing like this: [++]
 			// This will increment the value
-			var increment = /\[\+\+\]/g.exec(document[key]);
+			var increment = typeof document[key] === 'string' && /\[\+\+\]/g.exec(document[key]);
 
 			// Look for somthing like this: [--]
 			// This will decrement the value
-			var decrement = /\[\-\-\]/g.exec(document[key]);
+			var decrement = typeof document[key] === 'string' && /\[\-\-\]/g.exec(document[key]);
 
 			if (conditional) {
 

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 module.exports = (function() {
-
+f
 	var itemize = function(param) {
 
 		if (param === null) {
@@ -36,7 +36,7 @@ module.exports = (function() {
 
 				return {"SS" : param};
 
-			} else if (!isNaN(param[0])) {
+			} else if (typeof param[0] !== 'object' && !isNaN(param[0])) {
 
 				return {"NS" : param.map(function(n) {return "" + n; })};
 

--- a/utils.js
+++ b/utils.js
@@ -22,7 +22,7 @@ module.exports = (function() {
 
 			return {"S" : param.toString()};
 
-		} else if (!isNaN(param) && !Array.isArray(param)) {
+		} else if (typeof param !== 'object' && !Array.isArray(param) && !isNaN(param) ) {
 
 			return {"N" : "" + param};
 
@@ -52,9 +52,9 @@ module.exports = (function() {
 
 			return {"NULL" : true};
 
-		} else {
-
+		} else if (param.prototype) {
 			var object = {};
+
 			for (var key in param) {
 				if (param.hasOwnProperty(key)) {
 					var value = itemize(param[key]);
@@ -65,7 +65,17 @@ module.exports = (function() {
 			}
 
 			return {"M" : object};
+		} else {
+			var object = {};
 
+			for (var key in param) {
+				var value = itemize(param[key]);
+				if (value !== false) {
+					object[key] = value;
+				}
+			}
+
+			return {"M" : object};
 		}
 
 	};


### PR DESCRIPTION
Seems while using Apollo some objects constructed as input types were not inheriting from Object. Seems this can happen when using Object.create(null), etc.

isNaN fails with that kind of Object, and param.hasOwnProperty is also not available

cheers